### PR TITLE
Android tooling upgrade

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath "com.android.tools.build:gradle:3.6.1"
+    classpath "com.android.tools.build:gradle:4.0.2"
     classpath "org.codehaus.groovy:groovy-android-gradle-plugin:2.0.1"
     classpath "org.jfrog.buildinfo:build-info-extractor-gradle:latest.release"
   }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -34,8 +34,8 @@ artifactory {
     contextUrl = "https://thitu.jfrog.io/artifactory"
     repository {
       repoKey = "releases"
-      username = "JFROG_USERNAME"
-      password = "JFROG_PASSWORD"
+      username = JFROG_USERNAME
+      password = JFROG_PASSWORD
     }
     defaults {
       publications("mavenJava")

--- a/publishing.gradle
+++ b/publishing.gradle
@@ -34,8 +34,8 @@ artifactory {
     contextUrl = "https://thitu.jfrog.io/artifactory"
     repository {
       repoKey = "releases"
-      username = JFROG_USERNAME
-      password = JFROG_PASSWORD
+      username = "JFROG_USERNAME"
+      password = "JFROG_PASSWORD"
     }
     defaults {
       publications("mavenJava")


### PR DESCRIPTION
Updates android build tools and gradle wrapper so they don't fall too much behind what the app and sdk are using. Also I believe this will fix our failing passport sdk build.